### PR TITLE
CLTK-16: 일반 로그인 기능 추가

### DIFF
--- a/src/main/java/team/closetalk/user/config/WebSecurityConfig.java
+++ b/src/main/java/team/closetalk/user/config/WebSecurityConfig.java
@@ -23,6 +23,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(
                         authHttp -> authHttp.requestMatchers(
                                 "/users/register"
+                                , "/users/login"
                         ).permitAll()
                 ).sessionManagement(
                         sessionManagement -> sessionManagement.sessionCreationPolicy(

--- a/src/main/java/team/closetalk/user/controller/UserController.java
+++ b/src/main/java/team/closetalk/user/controller/UserController.java
@@ -2,11 +2,16 @@ package team.closetalk.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 import team.closetalk.user.dto.CustomUserDetails;
+import team.closetalk.user.dto.JwtTokenDto;
 import team.closetalk.user.service.UserService;
+import team.closetalk.user.utils.JwtUtils;
 
 @Slf4j
 @RestController
@@ -15,7 +20,7 @@ import team.closetalk.user.service.UserService;
 public class UserController {
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
-
+    private final JwtUtils jwtUtils;
     //회원가입
     @PostMapping(value = "/register"
             , consumes = "multipart/form-data"
@@ -44,6 +49,23 @@ public class UserController {
             log.warn("password mismatch");
             return "mismatch";
         }
+
+    }
+
+    @PostMapping("/login")
+    public JwtTokenDto loginUser(@RequestParam("loginId") String loginId
+                            , @RequestParam("password") String password
+    ){//토큰 반환?
+        log.info("password: {}, encodedPassword: {}", password, passwordEncoder.encode(password));
+
+        //반환된 값은 아이디 유무, 소셜여부까지 확인된 것(우선 없는 것만 통과)
+        CustomUserDetails responseUser = userService.loadUserByUsername(loginId);
+        passwordEncoder.matches(password, responseUser.getPassword());
+
+        JwtTokenDto response = new JwtTokenDto();
+        response.setToken(jwtUtils.generateToken(responseUser));
+
+        return response;
 
     }
 

--- a/src/main/java/team/closetalk/user/dto/CustomUserDetails.java
+++ b/src/main/java/team/closetalk/user/dto/CustomUserDetails.java
@@ -34,6 +34,7 @@ public class CustomUserDetails implements UserDetails {
                 .id(entity.getId())
                 .loginId(entity.getLoginId())
                 .nickname(entity.getNickname())
+                .password(entity.getPassword())
                 .email(entity.getEmail())
                 .profileImageUrl(entity.getProfileImageUrl())
                 .social(entity.getSocial())

--- a/src/main/java/team/closetalk/user/dto/JwtTokenDto.java
+++ b/src/main/java/team/closetalk/user/dto/JwtTokenDto.java
@@ -1,0 +1,8 @@
+package team.closetalk.user.dto;
+
+import lombok.Data;
+
+@Data
+public class JwtTokenDto {
+    private String token;
+}

--- a/src/main/java/team/closetalk/user/repository/UserRepository.java
+++ b/src/main/java/team/closetalk/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package team.closetalk.user.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.closetalk.user.entity.UserEntity;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByLoginId(String LoginId);
@@ -10,4 +12,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     boolean existsByNickname(String nickname);
 
     boolean existsByEmail(String email);
+
+    Optional<UserEntity> findByLoginId(String username);
 }

--- a/src/main/java/team/closetalk/user/service/UserService.java
+++ b/src/main/java/team/closetalk/user/service/UserService.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -111,8 +112,16 @@ public class UserService implements UserDetailsManager {
     }
 
     //로그인
-    public void loginUser(UserDetails user){
 
+    @Override
+    public CustomUserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        Optional<UserEntity> optionalUser = userRepository.findByLoginId(loginId);
+
+        if(optionalUser.isEmpty()) throw new UsernameNotFoundException(loginId);
+        if(optionalUser.get().getSocial() != null) throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+
+
+        return CustomUserDetails.fromEntity(optionalUser.get());
     }
 
 
@@ -136,8 +145,4 @@ public class UserService implements UserDetailsManager {
         return false;
     }
 
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return null;
-    }
 }

--- a/src/main/java/team/closetalk/user/utils/JwtUtils.java
+++ b/src/main/java/team/closetalk/user/utils/JwtUtils.java
@@ -6,9 +6,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import team.closetalk.user.dto.CustomUserDetails;
 
 import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
 
 @Slf4j
 @Component
@@ -39,5 +43,17 @@ public class JwtUtils {
             log.warn("invalid jwt: {}", e.getClass());
             return false;
         }
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        Claims jwtClaims = Jwts.claims()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(Date.from(Instant.now()))
+                .setExpiration(Date.from(Instant.now().plusSeconds(1200)));
+
+        return Jwts.builder()
+                .setClaims(jwtClaims)
+                .signWith(signingKey)
+                .compact();
     }
 }


### PR DESCRIPTION
추가 사항
- JWT 전달용 DTO 파일 추가(JwtTokenDto)
- JWT 발급 메보드 추가(JwtUtils)
- 로그인 관련 로직 추가(Controller, Service, Repository), 기존에 UserService에 작성된 로그인 로직은 삭제
- 로그인 요청 URL 추가(WebSecurityConfig)

수정 사항
- CustomUserDetails의 메소드 fromEntity에 password 추가