### PR TITLE
CLTK-17: 소셜 로그인 기능 추가 및 회원가입 시 이메일 인증용 메일 발송 기능 추가

### DIFF
--- a/src/main/java/team/closetalk/user/config/EmailConfig.java
+++ b/src/main/java/team/closetalk/user/config/EmailConfig.java
@@ -1,0 +1,7 @@
+package team.closetalk.user.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmailConfig {
+}

--- a/src/main/java/team/closetalk/user/config/WebSecurityConfig.java
+++ b/src/main/java/team/closetalk/user/config/WebSecurityConfig.java
@@ -9,27 +9,53 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import team.closetalk.user.service.CustomOAuth2UserService;
 import team.closetalk.user.utils.JwtFilter;
+import team.closetalk.user.utils.OAuth2SuccessHandler;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class WebSecurityConfig {
     private final JwtFilter jwtFilter;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
         http.csrf(AbstractHttpConfigurer :: disable)
                 .authorizeHttpRequests(
                         authHttp -> authHttp.requestMatchers(
-                                "/users/register"
-                                , "/users/login"
+                                "/"
+                                ,"/testPage"
+                                , "/js/join-form.js"
+//                                "/main"
+//                                , "relayAuth"
                         ).permitAll()
+                        .requestMatchers(
+                                "/joinPage"
+                                , "/users/sendEmail"
+                                , "/users/register"
+                                , "/users/login"
+                        ).anonymous()
+//                        .requestMatchers(
+//                                "/myPage"
+////                                , "/users/userInfo"
+////                                , "/authPage"
+//                        ).authenticated()
+
                 )
                 //폼로그인 추가
                 .formLogin( formHttp -> formHttp.loginPage("/loginPage")
                         .defaultSuccessUrl("/loginPage")
                         .failureUrl("/loginPage")
+                        .permitAll()
+                )
+                //소셜로그인 추가
+                .oauth2Login( oauthHttp -> oauthHttp.loginPage("/loginPage")
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureUrl("/loginPage")
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .permitAll()
                 )
                 .sessionManagement(

--- a/src/main/java/team/closetalk/user/dto/CustomUserDetails.java
+++ b/src/main/java/team/closetalk/user/dto/CustomUserDetails.java
@@ -11,8 +11,6 @@ import java.util.Date;
 
 @Data
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
     private Long id;

--- a/src/main/java/team/closetalk/user/dto/EmailAuthDto.java
+++ b/src/main/java/team/closetalk/user/dto/EmailAuthDto.java
@@ -1,0 +1,11 @@
+package team.closetalk.user.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class EmailAuthDto {
+    String email;
+    String authCode;
+}

--- a/src/main/java/team/closetalk/user/entity/UserEntity.java
+++ b/src/main/java/team/closetalk/user/entity/UserEntity.java
@@ -16,7 +16,7 @@ import java.util.Date;
 @Table(name = "users")
 public class UserEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 //    @Column(name = "login_id", unique = true)

--- a/src/main/java/team/closetalk/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/team/closetalk/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,63 @@
+package team.closetalk.user.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        //서비스 제공자 정보(ex: naver, kakako 등 yaml registration에 등록된 clientID?)
+        String registrationId = userRequest.getClientRegistration()
+                .getRegistrationId();
+        log.info("서비스 제공자 정보 registrationID: {}", registrationId);
+
+        String loginIdAttrbute = "";  //무슨 용도?
+        Map<String, Object> attributes = new HashMap<>();
+
+        //네이버
+        if (registrationId.equals("naver")) {
+            attributes.put("provider", "naver");
+
+            // 받은 사용자 데이터를 정리한다.
+            Map<String, Object> responseMap = oAuth2User.getAttribute("response");
+            attributes.put("id", responseMap.get("id"));
+            attributes.put("email", responseMap.get("email"));
+            attributes.put("nickname", responseMap.get("nickname"));
+            loginIdAttrbute = "email";
+        }
+
+        //카카오
+        if (registrationId.equals("kakao")) {
+            attributes.put("provider", "kakao");
+            attributes.put("id", oAuth2User.getAttribute("id").toString());
+
+            Map<String, Object> propMap = oAuth2User.getAttribute("properties");
+//            attributes.put("nickname", propMap.get("nickname"));
+            Map<String, Object> accountMap = oAuth2User.getAttribute("kakao_account");
+            attributes.put("email", accountMap.get("email"));
+            attributes.put("nickname", accountMap.get("email").toString().split("@")[0]);
+            loginIdAttrbute = "email";
+        }
+
+        log.info(attributes.toString());
+        // 기본설정으로는 여기까지 오면 인증 성공
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("USER")),
+                attributes,
+                loginIdAttrbute
+        );
+    }
+}

--- a/src/main/java/team/closetalk/user/service/EmailSendService.java
+++ b/src/main/java/team/closetalk/user/service/EmailSendService.java
@@ -1,0 +1,57 @@
+package team.closetalk.user.service;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSendService {
+    private final JavaMailSender javaMailSender;
+    private static final String ADMIN_ADDRESS = "xhxh006@naver.com";
+
+    private int authCode;
+
+    public void makeAuthCode(){
+        Random random = new Random();
+        authCode = random.nextInt(888888) + 111111;
+    }
+
+    public String makeEmailAuth(String receiver){
+        makeAuthCode();
+
+        String title = "[CloseTalk] 클로젯톡 회원가입을 위한 인증 메일입니다.";
+
+        String content = "귀하의 회원가입을 위한 이메일 인증번호입니다.\n"
+                +authCode;
+
+        sendEmail(receiver, title, content);
+
+        return Integer.toString(authCode);
+
+    }
+
+    public void sendEmail(String receiver, String title, String content){
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try{
+            mimeMessage.addRecipients(Message.RecipientType.TO, receiver);
+            mimeMessage.setSubject(title);
+            mimeMessage.setText(content);
+            mimeMessage.setFrom(new InternetAddress(ADMIN_ADDRESS, "CLOSETALK"));
+            javaMailSender.send(mimeMessage);
+        } catch (MessagingException e){
+            throw new RuntimeException(e);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/team/closetalk/user/service/UserService.java
+++ b/src/main/java/team/closetalk/user/service/UserService.java
@@ -42,7 +42,7 @@ public class UserService implements UserDetailsManager {
         String imagePath = PROFILE_IMAGE_DIRECTORY + PROFILE_IMAGE_DEFAULT;
 
         //이미지를 등록한 경우 imagePath 변경 및 이미지 파일 저장
-        if(!profileImage.isEmpty()){
+        if(profileImage != null && !profileImage.isEmpty()){
             //이미지 확장자명 가져오기
             String[] originalFilenameSplit = profileImage.getOriginalFilename().split("\\.");
             String extension = originalFilenameSplit[originalFilenameSplit.length - 1];
@@ -118,7 +118,7 @@ public class UserService implements UserDetailsManager {
         Optional<UserEntity> optionalUser = userRepository.findByLoginId(loginId);
 
         if(optionalUser.isEmpty()) throw new UsernameNotFoundException(loginId);
-        if(optionalUser.get().getSocial() != null) throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+//        if(optionalUser.get().getSocial() != null) throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
 
 
         return CustomUserDetails.fromEntity(optionalUser.get());
@@ -142,7 +142,7 @@ public class UserService implements UserDetailsManager {
 
     @Override
     public boolean userExists(String username) {
-        return false;
+        return userRepository.existsByLoginId(username);
     }
 
 }

--- a/src/main/java/team/closetalk/user/utils/JwtUtils.java
+++ b/src/main/java/team/closetalk/user/utils/JwtUtils.java
@@ -32,7 +32,7 @@ public class JwtUtils {
 
     //Jwt 파싱
     public Claims parseClaims(String token) {
-        return jwtParser.parseClaimsJwt(token).getBody();
+        return jwtParser.parseClaimsJws(token).getBody();
     }
 
     public boolean validate(String token) {

--- a/src/main/java/team/closetalk/user/utils/OAuth2SuccessHandler.java
+++ b/src/main/java/team/closetalk/user/utils/OAuth2SuccessHandler.java
@@ -1,0 +1,66 @@
+package team.closetalk.user.utils;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import team.closetalk.user.dto.CustomUserDetails;
+import team.closetalk.user.service.UserService;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtUtils jwtUtils;
+    private final UserService userService;
+
+    //인증에 성공했을 때
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User =(OAuth2User) authentication.getPrincipal();
+
+        String provider = oAuth2User.getAttribute("provider");
+        String providerId = oAuth2User.getAttribute("id"); //이거의 역할? 로그인 할 때마다 매번 달라지는지 확인 필요
+        log.info("이번 로그인 시도의 providerId는: {}", providerId);
+        String email = oAuth2User.getAttribute("email");
+        String loginId = email.split("@")[0]; //전달 받은 인증정보에서 이메일 앞자리로 따와서 loginId로 사용
+        String nickname = oAuth2User.getAttribute("nickname");
+
+        //최초 소셜로그인 시도인 경우 DB 등록
+        if(!userService.userExists(loginId)){
+            userService.createUser(CustomUserDetails.builder()
+                    .loginId(loginId)
+                    .password(providerId)
+                    .nickname(loginId)
+                    .email(email)
+                    .social(provider)
+                    .build()
+            );
+        }
+
+        //JWT 발급
+        CustomUserDetails customUserDetails = userService.loadUserByUsername(loginId);
+        String token = jwtUtils.generateToken(customUserDetails);
+
+        //(임시) JWT 확인
+        log.info(token);
+
+//        response.addHeader("Authorization", "Bearer " + token);
+
+        response.sendRedirect("/testPage?token=" + token);
+    }
+}


### PR DESCRIPTION
추가 사항
- 소셜 로그인 적용을 위한 기능 및 설정 파일 추가
    : 소셜 로그인으로 받은 정보 처리 `CustomOAuth2UserService.java`
      소셜 로그인 성공 시 DB 등록 및  JWT 발급 `OAuth2SuccessHandler.java`
      
- 이메일 인증을 위한 기능 및 설정 파일 추가
    : 이메일 발송을 위한 설정 파일 추가 `EmailConfig.java` 
      이메일 발송 처리 로직 추가 `EmailSendService.java`
      이메일 인증 DTO 추가 `EmailAuthDto.java` 

수정 사항
- 소셜로그인, 회원가입 페이지 적용 및 이메일 발송을 위한 URL 추가 `WebSecurityConfig.java`
- 소셜 로그인 시 유저 존재 여부 확인 및 
-  이메일 인증을 위한 이메일 발송 메소드 추가 `UserController`

기타 수정사항
- 회원가입 페이지 연결 시 없는 데이터로 인해 DTO 생성 오류 발생 `CustomUseDetails.java`
    : `@NoArgsContructor`, `@AllArgsContructor` 삭제하고 `@Builder`만 사용
- registerUser() 리턴타입 `String` -> `void` 로 수정 `UserController.java`
- 신규 회원가입 시 ID 값이 기존 데이터베이스에 있는 값에 이어서 진행하지 않고 1부터 진행하여 duplicate 발생 `UserEntity.java`
      : ID 값 생성 전략 수정 defualt -> `GenarateStrategy.IDENTITY`
- `saveProfileImage()`에서 이미지 저장 시 사용자가 이미지를 등록했는지 아닌지 체크 `UserServiece.java`
- 사용하지 않는 메소드 삭제
   : `UserController.registerProfileImage()`