### PR TITLE
CLTK-47 : 커뮤니티 Update 및 Delete 추가

### DIFF
--- a/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
+++ b/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
@@ -2,10 +2,15 @@ package team.closetalk.community.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.security.core.Authentication;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import team.closetalk.community.dto.CommunityArticleDto;
 import team.closetalk.community.service.CommunityArticleService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @RestController
 @RequestMapping("/community")
@@ -41,11 +46,23 @@ public class CommunityArticleController {
         return communityArticleService.readArticleOne(articleId);
     }
 
+    // 게시글 수정
+    @PutMapping("/{articleId}")
+    public CommunityArticleDto update(
+            @PathVariable Long articleId,
+            @RequestBody CommunityArticleDto dto,
+            Authentication authentication
+    ) {
+        dto.setModifiedAt(LocalDate.now(ZoneId.of("Asia/Seoul")));
+        return communityArticleService.updateCommunityArticle(articleId, dto, authentication);
+    }
+
     // 게시글 삭제
     @DeleteMapping("/{articleId}")
     public void deleteArticle(
-            @PathVariable Long articleId
+            @PathVariable Long articleId,
+            Authentication authentication
     ) {
-        communityArticleService.deleteArticle(articleId);
+        communityArticleService.deleteArticle(articleId, authentication);
     }
 }

--- a/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
+++ b/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
@@ -7,10 +7,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import team.closetalk.community.dto.CommunityArticleDto;
 import team.closetalk.community.service.CommunityArticleService;
-import team.closetalk.user.dto.CustomUserDetails;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 @RestController
@@ -55,11 +53,11 @@ public class CommunityArticleController {
             Authentication authentication
     ) {
         dto.setModifiedAt(LocalDate.now(ZoneId.of("Asia/Seoul")));
+//        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+//        String nickname = customUserDetails.getNickname();
+//        Long userId = customUserDetails.getId();
 
-        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
-        String nickname = customUserDetails.getNickname();
-
-        return communityArticleService.updateCommunityArticle(articleId, dto, nickname);
+        return communityArticleService.updateCommunityArticle(articleId, authentication, dto);
     }
 
     // 게시글 삭제

--- a/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
+++ b/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
@@ -7,6 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import team.closetalk.community.dto.CommunityArticleDto;
 import team.closetalk.community.service.CommunityArticleService;
+import team.closetalk.user.dto.CustomUserDetails;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -54,7 +55,11 @@ public class CommunityArticleController {
             Authentication authentication
     ) {
         dto.setModifiedAt(LocalDate.now(ZoneId.of("Asia/Seoul")));
-        return communityArticleService.updateCommunityArticle(articleId, dto, authentication);
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        String nickname = customUserDetails.getNickname();
+
+        return communityArticleService.updateCommunityArticle(articleId, dto, nickname);
     }
 
     // 게시글 삭제

--- a/src/main/java/team/closetalk/community/dto/CommunityArticleDto.java
+++ b/src/main/java/team/closetalk/community/dto/CommunityArticleDto.java
@@ -60,6 +60,7 @@ public class CommunityArticleDto {
     public static CommunityArticleDto fromEntity2(CommunityArticleEntity entity) {
         CommunityArticleDto dto = new CommunityArticleDto();
         dto.setId(entity.getId());
+        dto.setCategory(entity.getCategory());
         dto.setTitle(entity.getTitle());
         dto.setContent(entity.getContent());
         dto.setCreatedAt(entity.getCreatedAt());
@@ -73,6 +74,16 @@ public class CommunityArticleDto {
         if (comments != null && !comments.isEmpty()) {
             dto.setCommunityComments(comments.stream().map(CommunityCommentDto::fromEntity).collect(Collectors.toList()));
         }
+        return dto;
+    }
+
+    public static CommunityArticleDto toUpdate(CommunityArticleEntity entity) {
+        CommunityArticleDto dto = new CommunityArticleDto();
+        dto.setId(entity.getId());
+        dto.setCategory(entity.getCategory());
+        dto.setTitle(entity.getTitle());
+        dto.setContent(entity.getContent());
+        dto.setModifiedAt(entity.getModifiedAt());
         return dto;
     }
 }

--- a/src/main/java/team/closetalk/community/entity/CommunityArticleEntity.java
+++ b/src/main/java/team/closetalk/community/entity/CommunityArticleEntity.java
@@ -3,6 +3,7 @@ package team.closetalk.community.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import team.closetalk.user.entity.UserEntity;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -29,4 +30,8 @@ public class CommunityArticleEntity {
 
     @OneToMany(mappedBy = "communityArticle")
     private List<CommunityCommentEntity> communityComments = new ArrayList<>();
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
 }

--- a/src/main/java/team/closetalk/community/repository/CommunityArticleRepository.java
+++ b/src/main/java/team/closetalk/community/repository/CommunityArticleRepository.java
@@ -1,7 +1,14 @@
 package team.closetalk.community.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.closetalk.community.entity.CommunityArticleEntity;
 
+import java.util.Optional;
+
 public interface CommunityArticleRepository extends JpaRepository<CommunityArticleEntity, Long> {
+    Optional<CommunityArticleEntity> findByIdAndUserId(Long articleId, Long userId);
+
+    Page<CommunityArticleEntity> findByCategory(String category, Pageable pageable);
 }

--- a/src/main/java/team/closetalk/community/service/CommunityArticleService.java
+++ b/src/main/java/team/closetalk/community/service/CommunityArticleService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 import team.closetalk.community.dto.CommunityArticleDto;
@@ -40,9 +41,23 @@ public class CommunityArticleService {
         } else throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
 
+    // 게시글 수정
+    public CommunityArticleDto updateCommunityArticle(Long id, CommunityArticleDto dto, Authentication authentication) {
+        Optional<CommunityArticleEntity> optionalCommunityArticle = communityArticleRepository.findById(id);
+        if (optionalCommunityArticle.isPresent()) {
+            CommunityArticleEntity communityArticle = optionalCommunityArticle.get();
+            communityArticle.setTitle(dto.getTitle());
+            communityArticle.setContent(dto.getContent());
+            communityArticle.setModifiedAt(dto.getModifiedAt());
+            communityArticleRepository.save(communityArticle);
+            return CommunityArticleDto.fromEntity(communityArticle);
+        }
+        else throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    }
+
     // DELETE
     // 게시글 삭제
-    public void deleteArticle(Long articleId) {
+    public void deleteArticle(Long articleId, Authentication authentication) {
         // 게시글 찾기
         Optional<CommunityArticleEntity> optionalCommunity = communityArticleRepository.findById(articleId);
         if (optionalCommunity.isEmpty()) throw new ResponseStatusException(HttpStatus.NOT_FOUND);


### PR DESCRIPTION
Update 및 Delete 작성자가 수정 및 삭제 할 수 있게 추가하였습니다.

data.sql 파일 COMMUNIT_ARTICLE INSERT문에 user_id 및 SELECT id FROM users LIMIT 1 OFFSET 0 

추가하여야 작동이 가능하나 충돌 우려로 sql 파일은 추가하지 않았습니다.

추가로 commit에 IssueArticle이 아니라 CommunityArticle 입니다.