### PR TITLE
CLTK-51 : 게시물 생성 수정 - 이미지 관련

### DIFF
--- a/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
+++ b/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import team.closetalk.community.dto.CommunityArticleDto;
 import team.closetalk.community.dto.CommunityArticleListDto;
 import team.closetalk.community.enumeration.Category;
 import team.closetalk.community.service.CommunityArticleService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/community")
@@ -62,8 +65,9 @@ public class CommunityArticleController {
     // 게시글 생성
     @PostMapping("/create")
     public CommunityArticleDto createArticle(@RequestBody CommunityArticleDto dto,
+                                             @RequestParam("images") List<MultipartFile> imageList,
                                              Authentication authentication
                                              ) {
-        return communityArticleService.createArticle(dto, authentication);
+        return communityArticleService.createArticle(dto, imageList, authentication);
     }
 }

--- a/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
+++ b/src/main/java/team/closetalk/community/controller/CommunityArticleController.java
@@ -7,10 +7,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import team.closetalk.community.dto.CommunityArticleDto;
 import team.closetalk.community.dto.CommunityArticleListDto;
+import team.closetalk.community.dto.CommunityCreateArticleDto;
 import team.closetalk.community.enumeration.Category;
 import team.closetalk.community.service.CommunityArticleService;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/community")
@@ -64,10 +66,15 @@ public class CommunityArticleController {
 
     // 게시글 생성
     @PostMapping("/create")
-    public CommunityArticleDto createArticle(@RequestBody CommunityArticleDto dto,
-                                             @RequestParam("images") List<MultipartFile> imageList,
+    public CommunityArticleDto createArticle(@RequestPart(value = "data") CommunityCreateArticleDto dto,
+                                             @RequestPart(value = "imageUrl",
+                                                     required = false) List<MultipartFile> imageUrlList,
                                              Authentication authentication
                                              ) {
-        return communityArticleService.createArticle(dto, imageList, authentication);
+        Optional<List<MultipartFile>> optionalImageUrlList = Optional.ofNullable(imageUrlList);
+        if (optionalImageUrlList.isPresent())
+            return communityArticleService.createArticleWithImages(dto, imageUrlList, authentication);
+         else
+             return communityArticleService.createArticle(dto, authentication);
     }
 }

--- a/src/main/java/team/closetalk/community/dto/CommunityCommentReplyDto.java
+++ b/src/main/java/team/closetalk/community/dto/CommunityCommentReplyDto.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import team.closetalk.community.entity.CommunityCommentEntity;
 
+import java.time.format.DateTimeFormatter;
+
 @Getter
 @Builder
 public class CommunityCommentReplyDto {
@@ -20,13 +22,15 @@ public class CommunityCommentReplyDto {
             return CommunityCommentReplyDto.builder()
                     .userName(comment.getUserId().getNickname())
                     .content(comment.getContent())
-                    .createdAt(comment.getCreatedAt() + " (수정됨)")
+                    .createdAt(comment.getCreatedAt()
+                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")) + " (수정됨)")
                     .build();
         } else {
             return CommunityCommentReplyDto.builder()
                     .userName(comment.getUserId().getNickname())
                     .content(comment.getContent())
-                    .createdAt(String.valueOf(comment.getCreatedAt()))
+                    .createdAt(comment.getCreatedAt()
+                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                     .build();
         }
     }

--- a/src/main/java/team/closetalk/community/dto/CommunityCreateArticleDto.java
+++ b/src/main/java/team/closetalk/community/dto/CommunityCreateArticleDto.java
@@ -1,0 +1,22 @@
+package team.closetalk.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+import team.closetalk.community.enumeration.Category;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class CommunityCreateArticleDto {
+    private Category category;    // 카테고리
+    private String title;       // 제목
+    private String content;     // 내용
+
+    private List<MultipartFile> communityImages;
+}

--- a/src/main/java/team/closetalk/community/entity/CommunityArticleEntity.java
+++ b/src/main/java/team/closetalk/community/entity/CommunityArticleEntity.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Value;
 import org.hibernate.annotations.ColumnDefault;
 import team.closetalk.community.enumeration.Category;
 import team.closetalk.user.entity.UserEntity;
@@ -15,7 +14,7 @@ import java.time.ZoneId;
 
 @Data
 @Entity
-@Table(name = "communityArticle")
+@Table(name = "community_article")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommunityArticleEntity {
     @Id

--- a/src/main/java/team/closetalk/community/entity/CommunityArticleImagesEntity.java
+++ b/src/main/java/team/closetalk/community/entity/CommunityArticleImagesEntity.java
@@ -2,19 +2,25 @@ package team.closetalk.community.entity;
 
 
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.*;
 
-@Data
+@Getter
 @Entity
-@Table(name = "communityArticleImages")
+@Table(name = "community_article_images")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommunityArticleImagesEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private String imageUrl;
 
-    @ManyToOne
-    @JoinColumn(name = "communityArticle_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "community_article_id")
     private CommunityArticleEntity communityArticle;
+
+    public CommunityArticleImagesEntity(CommunityArticleEntity article,
+                                        String imageFilePath) {
+        this.communityArticle = article;
+        this.imageUrl = imageFilePath;
+    }
 }

--- a/src/main/java/team/closetalk/community/entity/CommunityCommentEntity.java
+++ b/src/main/java/team/closetalk/community/entity/CommunityCommentEntity.java
@@ -12,7 +12,7 @@ import java.time.ZoneId;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "communityComment")
+@Table(name = "community_comment")
 public class CommunityCommentEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,7 +31,7 @@ public class CommunityCommentEntity {
     private UserEntity userId;
 
     @ManyToOne
-    @JoinColumn(name = "communityArticle")
+    @JoinColumn(name = "community_article")
     private CommunityArticleEntity communityArticle;
 
     @ManyToOne

--- a/src/main/java/team/closetalk/community/service/CommunityArticleSaveImageService.java
+++ b/src/main/java/team/closetalk/community/service/CommunityArticleSaveImageService.java
@@ -1,0 +1,49 @@
+package team.closetalk.community.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+import team.closetalk.community.entity.CommunityArticleEntity;
+import team.closetalk.community.entity.CommunityArticleImagesEntity;
+import team.closetalk.community.repository.CommunityArticleImagesRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommunityArticleSaveImageService {
+    private final CommunityArticleImagesRepository imagesRepository;
+
+    public void saveArticleImage(CommunityArticleEntity article,
+                                    List<MultipartFile> articleImages){
+        //이미지 저장 디렉토리 생성
+        String ARTICLE_IMAGE_DIRECTORY =
+                String.format("src/main/resources/static/images/community/%d", article.getId());
+        try {
+            Files.createDirectories(Path.of(ARTICLE_IMAGE_DIRECTORY));
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+        }
+
+        for (MultipartFile image : articleImages) {
+            String imageFileName = image.getOriginalFilename();
+            assert imageFileName != null;
+            String imageFilePath = Path.of(ARTICLE_IMAGE_DIRECTORY, imageFileName).toString();
+
+            try {
+                image.transferTo(Path.of(imageFilePath));
+            } catch (IOException e) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+
+            imagesRepository.save(new CommunityArticleImagesEntity(article ,imageFilePath));
+        }
+    }
+}

--- a/src/main/java/team/closetalk/community/service/CommunityArticleService.java
+++ b/src/main/java/team/closetalk/community/service/CommunityArticleService.java
@@ -9,12 +9,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 import team.closetalk.closet.service.EntityRetrievalService;
-import team.closetalk.community.dto.CommunityArticleDto;
-import team.closetalk.community.dto.CommunityArticleImagesDto;
-import team.closetalk.community.dto.CommunityArticleListDto;
-import team.closetalk.community.dto.CommunityCommentDto;
+import team.closetalk.community.dto.*;
 import team.closetalk.community.entity.CommunityArticleEntity;
 import team.closetalk.community.entity.CommunityArticleImagesEntity;
 import team.closetalk.community.enumeration.Category;
@@ -36,6 +34,7 @@ public class CommunityArticleService {
     private final CommunityArticleImagesRepository communityArticleImagesRepository;
     private final EntityRetrievalService entityRetrievalService;
     private final CommunityCommentService communityCommentService;
+    private final CommunityArticleSaveImageService imageService;
 
     // 커뮤니티 전체 게시물 조회(페이지 단위로 조회)
     public Page<CommunityArticleListDto> readCommunityPaged(Integer pageNum, Integer pageSize) {
@@ -109,12 +108,23 @@ public class CommunityArticleService {
     }
 
     // 게시물 생성
-    public CommunityArticleDto createArticle(CommunityArticleDto dto,
+    public CommunityArticleDto createArticle(CommunityCreateArticleDto dto,
                                              Authentication authentication) {
         UserEntity user = getUserEntity(authentication.getName());
         CommunityArticleEntity article =
                 new CommunityArticleEntity(dto.getCategory(), dto.getTitle(), dto.getContent(), user);
         communityArticleRepository.save(article);
+        return readArticle(article.getId());
+    }
+
+    public CommunityArticleDto createArticleWithImages(CommunityCreateArticleDto dto,
+                                             List<MultipartFile> imageUrlList,
+                                             Authentication authentication) {
+        UserEntity user = getUserEntity(authentication.getName());
+        CommunityArticleEntity article =
+                new CommunityArticleEntity(dto.getCategory(), dto.getTitle(), dto.getContent(), user);
+        communityArticleRepository.save(article);
+        imageService.saveArticleImage(article, imageUrlList);
         return readArticle(article.getId());
     }
 


### PR DESCRIPTION
### 1. Jira 관련
원래 CLTK-5 : 커뮤니티 게시물 작성 페이지 구현 부분이지만, 
병합 및 오류 발생을 고려하여 CLTK-5 linked CLTK-4 식으로 타임라인 변경했습니다.

<br>

### 2. 게시물 이미지 포함 생성
 - [**1) 게시물 생성 수정**](https://github.com/Oh3gwnn/Project_Closetalk/commit/5c4896061f45be413e03adadcd77df323536e73f) 

    - CommunityArticleController (1) : image 유무에 따라 service 생성 로직 다르게 설정
    (`createArticle()`, `createArticleWithImages()`)
    - CommunityArticleController (2) : RequestPart 사용 -> Json, Form-Data 둘 다 받게끔 설정
    - CommunityCreateArticleDto : Controller를 통해 받는 Data
    - CommunityArticleImagesEntity : 생성자 추가
    - CommunityArticleSaveImageService : 이미지 저장 클래스
    - CommunityArticleService : createArticleWithImages 메서드 추가

 - [**2) 기타 수정사항**](https://github.com/Oh3gwnn/Project_Closetalk/commit/0454850a5b1663469ce9e6b0175e8b017ae05f2b) 

    - CommunityArticleEntity, CommunityCommentEntity : 테이블 명 수정
    - CommunityCommentReplyDto : DateTimeFormatter 추가

Closet 부분에서 옷장 이미지를 가져와 게시물을 작성하는 부분은 2023-09-03에 진행해보겠습니다.
<br>