### PR TITLE
CLTK-9 : 게시글 생성시 OOTD_ARTICLE_IMAGES에 article_id 누락되는 부분 수정

### DIFF
--- a/src/main/java/team/closetalk/ootd/service/OotdArticleService.java
+++ b/src/main/java/team/closetalk/ootd/service/OotdArticleService.java
@@ -91,6 +91,7 @@ public class OotdArticleService {
             String imagePath = saveOotdImageFile(imageList.get(i), articleId);
             OotdArticleImagesEntity imageEntity = new OotdArticleImagesEntity();
             imageEntity.setImageUrl(imagePath);
+            imageEntity.setOotdArticle(ootdArticleEntity);
             ootdArticleImagesRepository.save(imageEntity);
             if(i == 0) { //OOTD ARTICLE 썸네일 경로 저장
                 savedOotdArticle.setThumbnail(imagePath);


### PR DESCRIPTION
[CLTK-9: OotdArticleImages 저장할 때 ootd_article_id 누락된 부분 추가](https://github.com/Oh3gwnn/Project_Closetalk/commit/f7e55a517feda36c33d5eb9c1fe04d1d2851845b)
- 게시글 생성시 OOTD_ARTICLE_IMAGES에 article_id 누락되는 부분 수정